### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/RodneyYamane/juice-shop/security/code-scanning/53](https://github.com/RodneyYamane/juice-shop/security/code-scanning/53)

To fix the issue, we must prevent the direct inclusion of user input into JavaScript code passed to the `$where` operator. The best solution is to avoid using `$where` altogether and rely on standard query operators, which are safer and do not evaluate JavaScript. In this case, instead of filtering orders by `orderId` using `$where: "this.orderId === 'id'"`, use `{ orderId: id }` as the query filter. This is equivalent for equality checks and eliminates the possibility for code injection.

Specific changes:
- In routes/trackOrder.ts, replace the `$where` usage at line 18 with a direct query filter: `{ orderId: id }`.
- No additional utility methods or imports are necessary since this is standard MongoDB querying.
- No further changes are needed (the return processing remains untouched).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
